### PR TITLE
Unpacked-Directory-Path-Fix

### DIFF
--- a/AsarExtractor.cs
+++ b/AsarExtractor.cs
@@ -160,7 +160,7 @@ namespace AsarSharp
             {
                 if (_unpackedDirectoryPath == null)
                 {
-                    string unpackedDirectoryPath = Path.Join(Directory.GetParent(_pathToExtractDirectory).FullName, Path.GetFileName(_archiveFilePath) + ".unpacked");
+                    string unpackedDirectoryPath = Path.Join(Path.GetDirectoryName(_archiveFilePath), Path.GetFileName(_archiveFilePath) + ".unpacked");
                     if (!Directory.Exists(unpackedDirectoryPath))
                         throw new DirectoryNotFoundException(AsarExceptions.unpackedDirectoryMissing);
                     else


### PR DESCRIPTION
The local variable `unpackedDirectoryPath ` currently looks for the `outputFolder` + `inputFileName` + ".unpacked".

The current implementation would work if the extract directory were in the same directory as the `.asar` file.

The proposed implementation would remove the issue by implementing `inputFolder` + `inputFileName` + ".unpacked".

Allowing files to be output anywhere that is a valid directory.